### PR TITLE
fix task 2.2.33 on Server Core installations

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -498,6 +498,12 @@ sys_maxsize: 32768
 
 legalnoticecaption: "DoD Notice and Consent Banner"
 
+# 2.2.33
+# Window Manager\Window Manager Group only exists on non Core installations
+# windows_installation_type should be 'Server Core' for Core installations
+# This is a variable to determine if Windows Manager should be included in this step
+increase_scheduling_priority_users: '{{ ["Administrators"] if (windows_installation_type=="Server Core") else (["Administrators","Window Manager\Window Manager Group"]) }}'
+
 # 9.1.5
 # domain_firewall_log_path is the path to the domain firewall log files. The control suggests %SystemRoot%\System32\logfiles\firewall\domainfw.log
 # This is a variable to give some leway on where to store these log files

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,6 +25,16 @@
   tags:
       - always
 
+- name: Get Windows installation type
+  win_reg_stat:
+    path: HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion
+    name: InstallationType
+  register: get_windows_installation_type
+
+- name: Set Windows installation type
+  set_fact:
+    windows_installation_type: "{{ get_windows_installation_type.value | default('') }}"
+
 # - name: Include the preliminary tasks
 #   include_tasks: prelim.yml
 #   tags:

--- a/tasks/section02.yml
+++ b/tasks/section02.yml
@@ -453,9 +453,7 @@
 - name: "SCORED | 2.2.33 | PATCH | L1 Ensure Increase scheduling priority is set to Administrators Window ManagerWindow Manager Group"
   win_user_right:
       name: SeIncreaseBasePriorityPrivilege
-      users:
-          - Administrators
-          - Window Manager\Window Manager Group
+      users: "{{ increase_scheduling_priority_users }}"
       action: set
   when:
       - rule_2_2_33


### PR DESCRIPTION
This PR add steps to check windows installation type and fixes this issue: https://github.com/ansible-lockdown/Windows-2019-CIS/issues/48