### PR TITLE
Fixed typo in Private firewall policy registry key.

### DIFF
--- a/tasks/section09.yml
+++ b/tasks/section09.yml
@@ -114,7 +114,7 @@
 
 - name: "9.2.1 | PATCH | L1 |  Ensure 'Windows Firewall: Private: Firewall state' is set to 'On (recommended)'"
   win_regedit:
-      path: HKLM:SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile
+      path: HKLM:\SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile
       name: EnableFirewall
       data: 1
       type: dword


### PR DESCRIPTION
**Overall Review of Changes:**
A backslash was omitted in the task for patching item 9.2.1.  It has been corrected.

**Issue Fixes:**
N/A

**Enhancements:**
N/A

**How has this been tested?:**
Molecule testing indicates that the role successfully executes this task.
