### PR TITLE
Check Mode for section 17 2 commits as after commit I found another.

### DIFF
--- a/tasks/section17.yml
+++ b/tasks/section17.yml
@@ -514,6 +514,7 @@
         win_shell: AuditPol /get /subcategory:"Authentication Policy Change" -r | ConvertFrom-Csv | Select-Object -expand "Inclusion Setting"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: rule_17_7_2_audit
 
       - name: " 17.7.2 | PATCH | L1 | Ensure Audit Authentication Policy Change is set to include Success"

--- a/tasks/section17.yml
+++ b/tasks/section17.yml
@@ -6,6 +6,7 @@
         register: rule_17_1_1_audit
         changed_when: false
         failed_when: false
+        check_mode: false
 
       - name: " 17.1.1 | PATCH | L1 | Ensure Audit Credential Validation is set to Success and Failure | Success"
         win_shell: AuditPol /set /subcategory:"Credential Validation" /success:enable
@@ -30,6 +31,7 @@
         win_shell: AuditPol /get /subcategory:"Kerberos Authentication Service" -r | ConvertFrom-Csv | Select-Object -expand "Inclusion Setting"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: rule_17_1_2_audit
 
       - name: " 17.1.2 | PATCH | L1 | Ensure 'Audit Kerberos Authentication Service' is set to 'Success and Failure' DC Only"
@@ -53,6 +55,7 @@
         win_shell: AuditPol /get /subcategory:"Kerberos Service Ticket Operations" -r | ConvertFrom-Csv | Select-Object -expand "Inclusion Setting"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: rule_17_1_3_audit
 
       - name: " 17.1.3 | PATCH | L1 | Ensure 'Audit Kerberos Service Ticket Operations' is set to 'Success and Failure'"
@@ -77,6 +80,7 @@
         register: rule_17_2_1_audit
         changed_when: false
         failed_when: false
+        check_mode: false
 
       - name: " 17.2.1 | PATCH | L1 | Ensure Audit Application Group Management is set to Success and Failure | Success"
         win_shell: AuditPol /set /subcategory:"Application Group Management" /success:enable
@@ -100,6 +104,7 @@
         register: rule_17_2_2_audit
         changed_when: false
         failed_when: false
+        check_mode: false
 
       - name: " 17.2.2 | PATCH | L1 | Ensure Audit Computer Account Management is set to include Success DC only"
         win_shell: AuditPol /set /subcategory:"Computer Account Management" /success:enable
@@ -120,6 +125,7 @@
         register: rule_17_2_3_audit
         changed_when: false
         failed_when: false
+        check_mode: false
 
       - name: " 17.2.3 | PATCH | L1 | Ensure Audit Distribution Group Management is set to include Success DC only"
         win_shell: AuditPol /set /subcategory:"Distribution Group Management" /success:enable
@@ -139,6 +145,7 @@
         register: rule_17_2_4_audit
         changed_when: false
         failed_when: false
+        check_mode: false
 
       - name: " 17.2.4 | PATCH | L1 | Ensure Audit Other Account Management Events is set to include Success DC only"
         win_shell: AuditPol /set /subcategory:"Other Account Management Events" /success:enable
@@ -158,6 +165,7 @@
         register: rule_17_2_5_audit
         changed_when: false
         failed_when: false
+        check_mode: false
 
       - name: " 17.2.5 | PATCH | L1 | Ensure Audit Security Group Management is set to include Success"
         win_shell: AuditPol /set /subcategory:"Security Group Management" /success:enable
@@ -176,6 +184,7 @@
         win_shell: AuditPol /get /subcategory:"User Account Management" -r | ConvertFrom-Csv | Select-Object -expand "Inclusion Setting"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: rule_17_2_6_audit
 
       - name: " 17.2.6 | PATCH | L1 | Ensure Audit User Account Management is set to Success and Failure | Success"
@@ -199,6 +208,7 @@
         win_shell: AuditPol /get /subcategory:"Plug and Play Events" -r | ConvertFrom-Csv | Select-Object -expand "Inclusion Setting"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: rule_17_3_1_audit
 
       - name: " 17.3.1 | PATCH | L1 | Ensure Audit PNP Activity is set to include Success"
@@ -218,6 +228,7 @@
         win_shell: AuditPol /get /subcategory:"Process Creation" -r | ConvertFrom-Csv | Select-Object -expand "Inclusion Setting"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: rule_17_3_2_audit
 
       - name: " 17.3.2 | PATCH | L1 | Ensure Audit Process Creation is set to include Success"
@@ -237,6 +248,7 @@
         win_shell: AuditPol /get /subcategory:"Directory Service Access" -r | ConvertFrom-Csv | Select-Object -expand "Inclusion Setting"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: rule_17_4_1_audit
 
       - name: " 17.4.1 | PATCH | L1 | Ensure Audit Directory Service Access is set to include Failure DC only"
@@ -255,6 +267,7 @@
         win_shell: AuditPol /get /subcategory:"Directory Service Changes" -r | ConvertFrom-Csv | Select-Object -expand "Inclusion Setting"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: rule_17_4_2_audit
 
       - name: " 17.4.2 | PATCH | L1 | Ensure Audit Directory Service Changes is set to include Success DC only"
@@ -273,6 +286,7 @@
         win_shell: AuditPol /get /subcategory:"Account Lockout" -r | ConvertFrom-Csv | Select-Object -expand "Inclusion Setting"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: rule_17_5_1_audit
 
       - name: " 17.5.1 | PATCH | L1 | Ensure Audit Account Lockout is set to include Failure"
@@ -292,6 +306,7 @@
         win_shell: AuditPol /get /subcategory:"Group Membership" -r | ConvertFrom-Csv | Select-Object -expand "Inclusion Setting"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: rule_17_5_2_audit
 
       - name: " 17.5.2 | PATCH | L1 | Ensure Audit Group Membership is set to include Success"
@@ -311,6 +326,7 @@
         win_shell: AuditPol /get /subcategory:"Logoff" -r | ConvertFrom-Csv | Select-Object -expand "Inclusion Setting"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: rule_17_5_3_audit
 
       - name: " 17.5.3 | PATCH | L1 | Ensure Audit Logoff is set to include Success"
@@ -330,6 +346,7 @@
         win_shell: AuditPol /get /subcategory:"Logon" -r | ConvertFrom-Csv | Select-Object -expand "Inclusion Setting"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: rule_17_5_4_audit
 
       - name: " 17.5.4 | PATCH | L1 | Ensure Audit Logon is set to Success and Failure | Success"
@@ -353,6 +370,7 @@
         win_shell: AuditPol /get /subcategory:"Other Logon/Logoff Events" -r | ConvertFrom-Csv | Select-Object -expand "Inclusion Setting"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: rule_17_5_5_audit
 
       - name: " 17.5.5 | PATCH | L1 | Ensure Audit Other LogonLogoff Events is set to Success and Failure | Success"
@@ -376,6 +394,7 @@
         win_shell: AuditPol /get /subcategory:"Special Logon" -r | ConvertFrom-Csv | Select-Object -expand "Inclusion Setting"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: rule_17_5_6_audit
 
       - name: " 17.5.6 | PATCH | L1 | Ensure Audit Special Logon is set to include Success"
@@ -395,6 +414,7 @@
         win_shell: AuditPol /get /subcategory:"Detailed File Share" -r | ConvertFrom-Csv | Select-Object -expand "Inclusion Setting"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: rule_17_6_1_audit
 
       - name: " 17.6.1 | PATCH | L1 | Ensure Audit Detailed File Share is set to include Failure"
@@ -414,6 +434,7 @@
         win_shell: AuditPol /get /subcategory:"File Share" -r | ConvertFrom-Csv | Select-Object -expand "Inclusion Setting"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: rule_17_6_2_audit
 
       - name: " 17.6.2 | PATCH | L1 | Ensure Audit File Share is set to Success and Failure"
@@ -449,6 +470,7 @@
         win_shell: AuditPol /get /subcategory:"Removable Storage" -r | ConvertFrom-Csv | Select-Object -expand "Inclusion Setting"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: rule_17_6_4_audit
 
       - name: " 17.6.4 | PATCH | L1 | Ensure Audit Removable Storage is set to Success and Failure"
@@ -472,6 +494,7 @@
         win_shell: AuditPol /get /subcategory:"Audit Policy Change" -r | ConvertFrom-Csv | Select-Object -expand "Inclusion Setting"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: rule_17_7_1_audit
 
       - name: " 17.7.1 | PATCH | L1 | Ensure Audit Audit Policy Change is set to include Success"
@@ -510,6 +533,7 @@
         win_shell: AuditPol /get /subcategory:"Authorization Policy Change" -r | ConvertFrom-Csv | Select-Object -expand "Inclusion Setting"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: rule_17_7_3_audit
 
       - name: " 17.7.3 | PATCH | L1 | Ensure Audit Authorization Policy Change is set to include Success"
@@ -529,6 +553,7 @@
         win_shell: AuditPol /get /subcategory:"MPSSVC Rule-Level Policy Change" -r | ConvertFrom-Csv | Select-Object -expand "Inclusion Setting"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: rule_17_7_4_audit
 
       - name: " 17.7.4 | PATCH | L1 | Ensure Audit MPSSVC Rule-Level Policy Change is set to Success and Failure | Success"
@@ -552,6 +577,7 @@
         win_shell: AuditPol /get /subcategory:"Other Policy Change Events" -r | ConvertFrom-Csv | Select-Object -expand "Inclusion Setting"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: rule_17_7_5_audit
 
       - name: " 17.7.5 | PATCH | L1 | Ensure Audit Other Policy Change Events is set to include Failure"
@@ -571,6 +597,7 @@
         win_shell: AuditPol /get /subcategory:"Sensitive Privilege Use" -r | ConvertFrom-Csv | Select-Object -expand "Inclusion Setting"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: rule_17_8_1_audit
 
       - name: " 17.8.1 | PATCH | L1 | Ensure Audit Sensitive Privilege Use is set to Success and Failure | Success"
@@ -594,6 +621,7 @@
         win_shell: AuditPol /get /subcategory:"IPsec Driver" -r | ConvertFrom-Csv | Select-Object -expand "Inclusion Setting"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: rule_17_9_1_audit
 
       - name: " 17.9.1 | PATCH | L1 | Ensure Audit IPsec Driver is set to Success and Failure | Success"
@@ -617,6 +645,7 @@
         win_shell: AuditPol /get /subcategory:"Other System Events" -r | ConvertFrom-Csv | Select-Object -expand "Inclusion Setting"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: rule_17_9_2_audit
 
       - name: " 17.9.2 | PATCH | L1 | Ensure Audit Other System Events is set to Success and Failure | Success"
@@ -640,6 +669,7 @@
         win_shell: AuditPol /get /subcategory:"Security State Change" -r | ConvertFrom-Csv | Select-Object -expand "Inclusion Setting"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: rule_17_9_3_audit
 
       - name: " 17.9.3 | PATCH | L1 | Ensure Audit Security State Change is set to include Success"
@@ -659,6 +689,7 @@
         win_shell: AuditPol /get /subcategory:"Security System Extension" -r | ConvertFrom-Csv | Select-Object -expand "Inclusion Setting"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: rule_17_9_4_audit
 
       - name: " 17.9.4 | PATCH | L1 | Ensure Audit Security System Extension is set to include Success"
@@ -678,6 +709,7 @@
         win_shell: AuditPol /get /subcategory:"System Integrity" -r | ConvertFrom-Csv | Select-Object -expand "Inclusion Setting"
         changed_when: false
         failed_when: false
+        check_mode: false
         register: rule_17_9_5_audit
 
       - name: " 17.9.5 | PATCH | L1 | Ensure Audit System Integrity is set to Success and Failure | Success"


### PR DESCRIPTION
**Overall Review of Changes:**
Fixed the Audit rules within section 17. You are now able to do --check when running ansible without failure. 

**Issue Fixes:**
None found issues. Mainly providing this as a thank you for the hard work you people did. Just wanted to give back

**Enhancements:**
 Able to do --check when running ansible-playbook. Given the option to do a audit run within ansible. Without using goss.

**How has this been tested?:**
Yes used "ansible-playbook site.yml -i inventory  -k --check -t section17" .  Though fixing the hole role would mean to go through testing all the tags. Some of the HKEY paths doesn't exist.

