### PR TITLE
Win Skip For Test Name Update, Set system facts based on gather facts module default vars

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -12,6 +12,7 @@ skip_list:
     - 'name[casing]'
     - 'name[template]'
     - 'jinja[spacing]'
+    - 'yaml[line-length]'
     - 'var-naming'  # Older playbook no new release
     - '204'
     - '208'

--- a/.github/workflows/main.tf
+++ b/.github/workflows/main.tf
@@ -188,6 +188,6 @@ resource "local_file" "inventory" {
         ansible_winrm_read_timeout_sec: 180
         # This section turns off and on the groups of controls for connections and tests.
         # Refer to default main for the controls here explanation.
-        win19cis_skip_for_test: true
+        win_skip_for_test: true
     EOF
 }

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,7 +42,7 @@ min_ansible_version: "2.10.1"
 # win19cis_rule_18_9_102_2_2
 # win19cis_rule_18_9_102_2_3
 # win19cis_rule_18_9_103_1
-win19cis_skip_for_test: false
+win_skip_for_test: false
 
 # These variables correspond with the CIS rule IDs or paragraph numbers defined in
 # the CIS benchmark documents.
@@ -121,7 +121,7 @@ win19cis_rule_2_3_1_2: true
 win19cis_rule_2_3_1_3: true
 win19cis_rule_2_3_1_4: true
 # Setting win19cis_rule_2_3_1_5 Control To True Will Break Ansible Connection
-# Setting win19cis_skip_for_test: true -- will skip the controls here even if they are set to true.
+# Setting win_skip_for_test: true -- will skip the controls here even if they are set to true.
 win19cis_rule_2_3_1_5: true
 win19cis_rule_2_3_1_6: true
 win19cis_rule_2_3_2_1: true
@@ -217,7 +217,7 @@ win19cis_rule_9_3_2: true
 win19cis_rule_9_3_3: true
 win19cis_rule_9_3_4: true
 # Setting win19cis_rule_9_3_5 Control To True Will Break Ansible Connection
-# Setting win19cis_skip_for_test: true -- will skip the controls here even if they are set to true.
+# Setting win_skip_for_test: true -- will skip the controls here even if they are set to true.
 win19cis_rule_9_3_5: true
 win19cis_rule_9_3_6: true
 win19cis_rule_9_3_7: true
@@ -449,7 +449,7 @@ win19cis_rule_18_9_100_1: true
 win19cis_rule_18_9_100_2: true
 # WINRM CONTROLS #
 # Setting The Following Controls To True Will Break Ansible Connection
-# Setting win19cis_skip_for_test: true -- will skip the controls here even if they are set to true.
+# Setting win_skip_for_test: true -- will skip the controls here even if they are set to true.
 # win19cis_rule_18_9_102_1_1
 # win19cis_rule_18_9_102_1_2
 # win19cis_rule_18_9_102_2_1

--- a/tasks/section02.yml
+++ b/tasks/section02.yml
@@ -834,7 +834,7 @@
             - "'adminchangethis' not in win19cis_admin_username"
   when:
       - win19cis_rule_2_3_1_5
-      - not win19cis_skip_for_test
+      - not win_skip_for_test
   tags:
       - level1-domaincontroller
       - level1-memberserver

--- a/tasks/section09.yml
+++ b/tasks/section09.yml
@@ -368,7 +368,7 @@
       type: dword
   when:
       - win19cis_rule_9_3_5
-      - not win19cis_skip_for_test
+      - not win_skip_for_test
   tags:
       - level1-domaincontroller
       - level1-memberserver

--- a/tasks/section18.yml
+++ b/tasks/section18.yml
@@ -3083,7 +3083,7 @@
       type: dword
   when:
       - win19cis_rule_18_9_102_1_1
-      - not win19cis_skip_for_test
+      - not win_skip_for_test
   tags:
       - level1-domaincontroller
       - level1-memberserver
@@ -3099,7 +3099,7 @@
       type: dword
   when:
       - win19cis_rule_18_9_102_1_2
-      - not win19cis_skip_for_test
+      - not win_skip_for_test
   tags:
       - level1-domaincontroller
       - level1-memberserver
@@ -3130,7 +3130,7 @@
       type: dword
   when:
       - win19cis_rule_18_9_102_2_1
-      - not win19cis_skip_for_test
+      - not win_skip_for_test
   tags:
       - level1-domaincontroller
       - level1-memberserver
@@ -3147,7 +3147,7 @@
       type: dword
   when:
       - win19cis_rule_18_9_102_2_2
-      - not win19cis_skip_for_test
+      - not win_skip_for_test
   tags:
       - level2-domaincontroller
       - level2-memberserver
@@ -3163,7 +3163,7 @@
       type: dword
   when:
       - win19cis_rule_18_9_102_2_3
-      - not win19cis_skip_for_test
+      - not win_skip_for_test
   tags:
       - level1-domaincontroller
       - level1-memberserver
@@ -3195,7 +3195,7 @@
       type: dword
   when:
       - win19cis_rule_18_9_103_1
-      - not win19cis_skip_for_test
+      - not win_skip_for_test
   tags:
       - level2-domaincontroller
       - level2-memberserver

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,7 +6,15 @@
 warn_control_list: ""
 warn_count: 0
 
+# This sets the variable that is created for the banner.
 lockdown_banner: "{{lookup('file', './templates/banner.txt')}}"
 
 # This will be changed to true if discovered.
 win19cis_cloud_based_system: false
+
+
+# These are default values that will be changed when the prelim
+# runs and finds the correct setting.
+win2019cis_is_standalone: false
+win2019cis_is_domain_controller: false
+win2019cis_is_domain_member: false


### PR DESCRIPTION
# Overall Review of Changes

Win Skip For Test Name Update, Set system facts based on gather facts module default vars were added to take into account when statements that had facts that were not set by default

## Issue Fixes

N\A

## Enhancements

N/A

## How has this been tested?

N/A
